### PR TITLE
Fix scaling issue I noticed, update copyright year

### DIFF
--- a/_includes/end.html
+++ b/_includes/end.html
@@ -1,6 +1,6 @@
       <footer>
           <a href="//github.com/multigraph/js-multigraph" class="icon"><i class="fa fa-github fa-3x"></i></a><br />
-          <p>&copy; 2014 <a href="//nemac.unca.edu"><abbr title="UNC Asheville's National Environmental Modeling & Analysis Center">UNC Asheville's NEMAC</abbr></a></p>
+          <p>&copy; <script>document.write(new Date().getFullYear())</script> <a href="//nemac.unca.edu"><abbr title="UNC Asheville's National Environmental Modeling & Analysis Center">UNC Asheville's NEMAC</abbr></a></p>
       </footer>
 
     </div>

--- a/css/multigraph.css
+++ b/css/multigraph.css
@@ -14,7 +14,7 @@
 .jumbotron p.lead {
     text-indent: 0.5cm;
 }
-.col-lg-4 h1, .col-lg-4 h2, .col-lg-4 p {
+.col-xs-6, .col-md-4 {
     /* center the 3 vector graphics */
     text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -17,17 +17,17 @@ about: selected
         <div class="multigraph" data-src="/examples/graphs/temp_forecast_frontpage.xml" data-width="100%" data-height="250"></div>
 
         <div class="row">
-          <div class="col-lg-4 panning">
+          <div class="col-xs-6 col-md-4 panning">
             <h1><i class="fa fa-arrows fa-3x"></i></h1>
             <h2>Panning</h2>
             <p>Just click and drag with your mouse (or finger) to drag the graph up and down!</p>
           </div>
-            <div class="col-lg-4 zooming">
+            <div class="col-xs-6 col-md-4 zooming">
               <h1><i class="fa fa-search-plus fa-3x"></i></h1>
               <h2>Zooming</h2>
               <p>Scroll in or scroll out using your mouse! Have hands? Just pinch to zoom!</p>
           </div>
-          <div class="col-lg-4 integrating">
+          <div class="col-xs-6 col-md-4 integrating">
             <h1><i class="fa fa-code fa-3x"></i></h1>
             <h2>Easily integrated</h2>
             <p>Just a few lines of code! Learn how to make your own graphs <a href="#">here</a>!</p>


### PR DESCRIPTION
When working on the Seldon site, I noticed I had used the incorrectly scaling classes (they would just stack instead of shrink) so I have applied the appropriate fixes to Multigraph's site as well, and switched to using a JavaScript call to get the year.