### PR TITLE
Remove highlighter from Jekyll configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
 name: Multigraph
 markdown: html
 markdown: rdiscount
-highlighter: true


### PR DESCRIPTION
The only highlighter supported by GitHub Pages is “pygments”, however
this is already enabled by GitHub by default, so there is no need to
add it.
